### PR TITLE
Move dependency of pear/http_request2 to 2.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "type": "library",
     "require": {
         "php": ">=5.4.0",
-        "pear/http_request2": "2.2.*",
+        "pear/http_request2": "2.3.*",
         "pear/log": "1.12.*"
     },
     "require-dev": {


### PR DESCRIPTION
Could we update the version of _pear/http_request2_ from **2.2.*** to **2.3.*** ?

Version details:
http://pear.php.net/package/HTTP_Request2/download/2.3.0
