### PR TITLE
Set dependency to php version 7.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "name": "kenguest/services-openstreetmap",
     "type": "library",
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
         "pear/http_request2": "2.3.*",
         "pear/log": "1.12.*|1.13.*",
         "ext-simplexml": "*"


### PR DESCRIPTION
Since Nullable Types are available off the beginning with php 7.1 the dependency should be adjusted.

When using lower php version the following line throws an error:
```php
// Line 293 at class Services_OpenStreetMap
public function getXml():? string
{
    return $this->xml;
}
```