### PR TITLE
Support for Oauth2

### DIFF
--- a/Services/OpenStreetMap/Config.php
+++ b/Services/OpenStreetMap/Config.php
@@ -24,6 +24,7 @@
  */
 class Services_OpenStreetMap_Config
 {
+    protected $oauth2_token = null;
     protected $oauth_consumer_key = null;
     protected $oauth_token = null;
     protected $oauth_token_secret = null;
@@ -153,6 +154,7 @@ class Services_OpenStreetMap_Config
         'user'            => null,
         'verbose'         => false,
         /* Fields for OAuth auth */
+        'oauth2_token'    => false,
         'oauth_token'     => false,
         'oauth_token_secret' => false,
         'oauth_consumer_key' => false,
@@ -241,6 +243,7 @@ class Services_OpenStreetMap_Config
      *  <li> 'User-Agent'         - User-Agent (string)</li>
      *  <li> 'user'               - user (string, optional)</li>
      *  <li> 'verbose'            - verbose (boolean, optional)</li>
+     *  <li> 'oauth2_token'       - false</li>
      *  <li> 'oauth_token'        - false</li>
      *  <li> 'oauth_token_secret' - false</li>
      *  <li> 'oauth_consumer_key' - false</li>
@@ -291,6 +294,7 @@ class Services_OpenStreetMap_Config
                 case 'accept_language':
                     $this->setAcceptLanguage($value);
                     break;
+                case 'oauth2_token':
                 case 'oauth_token':
                 case 'oauth_token_secret':
                 case 'oauth_consumer_key':


### PR DESCRIPTION
Extended code to support OAuth2. Two files are changed:

1. https://github.com/sascha-hendel/Services_Openstreetmap/blob/master/Services/OpenStreetMap/Config.php
2. https://github.com/sascha-hendel/Services_Openstreetmap/blob/master/Services/OpenStreetMap/Changeset.php

New config parameter **oauth2_token**:
`$config = array( 'oauth2_token' => 'YOUR_OAUTH2_TOKEN', ... further parameters ); $osm = new Services_OpenStreetMap($config);`

The routines to obtain OAuth2 authorization code and in second step the token are not included. Therefore You need to use an OAuth2 library or write your own code.  
